### PR TITLE
HealthTest BaseUrl property being called wrong

### DIFF
--- a/tests/unit/HealthTest.php
+++ b/tests/unit/HealthTest.php
@@ -26,7 +26,7 @@ class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		// Then check the actual config file
 		$reader = new \Tests\Support\Libraries\ConfigReader();
-		$config = ! empty($reader->baseUrl);
+		$config = ! empty($reader->baseURL);
 
 		$this->assertTrue($env || $config);
 	}


### PR DESCRIPTION
I just started working with CodeIgniter 4 and I am liking it so far but I did find an issue in your HealthTest that is causing the base url test to fail if you don't have the baseURL set in you .env file. This PR is to fix that by calling the baseURL property correctly.