### PR TITLE
Exclude unnecessary files when use composer create-project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+/.github export-ignore
+.gitattributes export-ignore
+builds export-ignore


### PR DESCRIPTION
When we use `composer create-project codeigniter4/appstarter project-root`, some files/folders such as `builds` and `.github/workflows` are included. Those files/folders might useful for core developers, but unnecessary for users. This PR will exclude those files/folders.