### PR TITLE
Correct test syntax

### DIFF
--- a/tests/unit/HealthTest.php
+++ b/tests/unit/HealthTest.php
@@ -21,12 +21,12 @@ class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 		// First check in .env
 		if (is_file(HOMEPATH . '.env'))
 		{
-			$env = (bool) preg_grep("/^app\.baseURL = './", file(HOMEPATH . '.env'));
+			$env = (bool) preg_grep("/^app\.baseURL = './", file(HOMEPATH . 'env'));
 		}
 
 		// Then check the actual config file
 		$reader = new \Tests\Support\Libraries\ConfigReader();
-		$config = ! empty($reader->baseUrl);
+		$config = ! empty($reader->baseURL);
 
 		$this->assertTrue($env || $config);
 	}


### PR DESCRIPTION
`tests/unit/HealthTest.php` used the wrong name of the env file (leading dot which does not exist) and the wrong ConfigReader::baseURL casing (Url instead of URL). 
The tests on master were failing right after checkout. This PR fixes the issues. 