### PR TITLE
Chore/upgrade composer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"codeigniter4/framework": "^4"
 	},
 	"require-dev": {
-		"fzaninotto/faker": "^1.9@dev",
+		"fakerphp/faker": "^1.9@dev",
 		"mikey179/vfsstream": "1.6.*",
 		"phpunit/phpunit": "^8.5"
 	},

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"require-dev": {
 		"fakerphp/faker": "^1.9@dev",
 		"mikey179/vfsstream": "1.6.*",
-		"phpunit/phpunit": "^8.5"
+		"phpunit/phpunit": "^9.5"
 	},
 	"autoload-dev": {
 		"psr-4": {


### PR DESCRIPTION
Two packeges have been marked as abandoned and need to be replaced. 
Citing composer here: 
```
Package fzaninotto/faker is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
```

- `fzaniotto/faker` has been forked into `fakerphp/faker` 
- `phpunit/php-token-stream` has been removed from newer versions of phpunit/phpunit, upgrading solved the issue. 