### PR TITLE
faker is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
 		"codeigniter4/framework": "^4"
 	},
 	"require-dev": {
-		"fzaninotto/faker": "^1.9@dev",
 		"mikey179/vfsstream": "1.6.*",
 		"phpunit/phpunit": "^8.5"
 	},


### PR DESCRIPTION
fzaninotto/Faker is deprecated and archived and breaks composer with error:
[RuntimeException]                                                                                                 
  Failed to clone https://github.com/fzaninotto/Faker.git, git was not found, check that it is installed and in your PATH env.

More info @
https://github.com/fzaninotto/Faker