### PR TITLE
Fixed baseURL test

### DIFF
--- a/tests/unit/HealthTest.php
+++ b/tests/unit/HealthTest.php
@@ -26,7 +26,7 @@ class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		// Then check the actual config file
 		$reader = new \Tests\Support\Libraries\ConfigReader();
-		$config = ! empty($reader->baseUrl);
+		$config = ! empty($reader->baseURL);
 
 		$this->assertTrue($env || $config);
 	}


### PR DESCRIPTION
The out-of-the-box experience with a failing test is not good IMHO. 
If the purpose is to have this test fail, simply ignore this PR.