### PR TITLE
Add composer.lock to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ phpunit
 # Composer
 #-------------------------
 vendor/
-
+composer.lock
 #-------------------------
 # IDE / Development Files
 #-------------------------


### PR DESCRIPTION
This commit for appstarter come from https://github.com/codeigniter4/CodeIgniter4/commit/d2e7f375ea2bffe5c36332fb0d6d9c64e1635063 commit on the
CodeIgniter4 and it's good to ignore this file in this case because you can control the version of any given library by composer.json using Semantic Versioning